### PR TITLE
FSUP-10060

### DIFF
--- a/.github/workflows/BuildAndTestOnEveryPush.yml
+++ b/.github/workflows/BuildAndTestOnEveryPush.yml
@@ -30,6 +30,6 @@ jobs:
       
     - name: Push NuGet package to the testfeed
       if: runner.os == 'Windows' 
-      run: dotnet nuget push Frends.Community.PowerShell\bin\Release\Frends.Community.PowerShell.*.nupkg  --api-key ${{ secrets.CommunityFeedApiKey }} --source https://www.myget.org/F/frends-community-test/api/v2/package --symbol-source https://www.myget.org/F/frends-community-test/symbols/api/v2/package
+      run: dotnet nuget push Frends.Community.PowerShell\bin\Release\Frends.Community.PowerShell.*.nupkg  --api-key ${{ secrets.CommunityFeedApiKey }} --source https://www.myget.org/F/frends-community-test/api/v2/package
 
 

--- a/.github/workflows/PackAndPushAfterMerge.yml
+++ b/.github/workflows/PackAndPushAfterMerge.yml
@@ -17,5 +17,5 @@ jobs:
       run: dotnet pack --configuration Release --include-source 
       
     - name: Push NuGet package to the (prod) feed
-      run: dotnet nuget push Frends.Community.PowerShell\bin\Release\Frends.Community.PowerShell.*.nupkg  --api-key ${{ secrets.CommunityFeedApiKey }} --source https://www.myget.org/F/frends-community/api/v2/package --symbol-source https://www.myget.org/F/frends-community/symbols/api/v2/package
+      run: dotnet nuget push Frends.Community.PowerShell\bin\Release\Frends.Community.PowerShell.*.nupkg  --api-key ${{ secrets.CommunityFeedApiKey }} --source https://www.myget.org/F/frends-community/api/v2/package
 

--- a/Frends.Community.PowerShell.Tests/Frends.Community.PowerShell.Tests.csproj
+++ b/Frends.Community.PowerShell.Tests/Frends.Community.PowerShell.Tests.csproj
@@ -8,11 +8,11 @@
 
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.10.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Frends.Community.PowerShell/Frends.Community.PowerShell.csproj
+++ b/Frends.Community.PowerShell/Frends.Community.PowerShell.csproj
@@ -10,7 +10,7 @@
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,9 +20,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -100,3 +100,4 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | 1.0.0   | First version |
 | 1.1.0   | Multi-framework and Github actions support  |
 | 1.2.0   | Option to turn information stream logging on or off |
+| 1.3.0   | Updated dependencies: Microsoft.CSharp to 4.7.0, PowerShellStandard.Library to 5.1.1, System.ComponentModel.Annotations to 5.0.0 |


### PR DESCRIPTION
- Dependencies updated to latest
- Checked for the possibility to add net6/net8 target frameworks as well, but the Powershell host doesn't seem to support multitargeting. Also corresponding official Frends tasks already exist for those frameworks.